### PR TITLE
Recover Codex driver after app updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
           bash tests/http-smoke.sh
           bash tests/installer-smoke.sh
           node tests/apns-push-smoke.mjs
+          node tests/codex-app-server-driver-smoke.mjs
           node tests/collaborator-host-smoke.mjs
           node tests/collaborator-cognition-smoke.mjs
           node tests/collaborator-conversation-smoke.mjs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.29.1
 
 - Recover computer collaborators when Codex becomes available after Host startup, while keeping passive driver status reads free of executable probes.
 - Replace private-style test fixture identities with neutral examples.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Recover computer collaborators when Codex becomes available after Host startup, while keeping passive driver status reads free of executable probes.
+- Replace private-style test fixture identities with neutral examples.
+
 ## 0.29.0
 
 - Add Host-owned one-shot and recurring initiative rules, owner-bound collaborator tools, Mac/Linux Console controls, and completed-turn APNs delivery to separately registered paired phones.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Aru Host 是 Aru 的用户自有能力节点。它把电脑或 VPS 变成一台可由 iPhone 配对、查看和使用的 Host，同时让电脑协作者的身份、对话、页面、记忆、工具权限和运行状态留在用户自己的机器上。
 
-当前稳定版是 **0.29.0**，Host 协议版本为 `stub-0.29`。它与当前 Aru TestFlight 版本配套使用，并提供面向普通 Mac 用户的 Apple 签名、公证安装包，以及面向 Debian/Ubuntu 桌面用户的 `x64` / `arm64` 安装包。
+当前稳定版是 **0.29.1**，Host 协议版本为 `stub-0.29`。它与当前 Aru TestFlight 版本配套使用，并提供面向普通 Mac 用户的 Apple 签名、公证安装包，以及面向 Debian/Ubuntu 桌面用户的 `x64` / `arm64` 安装包。
 
 ## 现在能做什么
 
@@ -52,7 +52,7 @@ Console 凭证只进入 Linux Secret Service；GNOME Keyring、KWallet 或其他
 如果桌面没有图形化软件安装器，也可以在下载目录运行：
 
 ```bash
-sudo apt install ./aru-host-linux-0.29.0-x64.deb
+sudo apt install ./aru-host-linux-0.29.1-x64.deb
 ```
 
 源码级当前用户安装器保留给开发和诊断：

--- a/codex-app-server-driver.mjs
+++ b/codex-app-server-driver.mjs
@@ -10,6 +10,7 @@ export function createCodexAppServerDriver({ executable, resolveExecutable, log 
   let process = null;
   let socket = null;
   let connecting = null;
+  let knownExecutable = executable ?? null;
   let requestSequence = 0;
   const pendingRequests = new Map();
   const threadHandlers = new Map();
@@ -17,12 +18,12 @@ export function createCodexAppServerDriver({ executable, resolveExecutable, log 
   function status() {
     if (socket?.readyState === WebSocket.OPEN) return "running";
     if (connecting) return "starting";
-    return executablePath() ? "ready" : "unavailable";
+    return knownExecutable ? "ready" : "unavailable";
   }
 
   async function ensureConnected() {
     if (socket?.readyState === WebSocket.OPEN) return;
-    const command = executablePath();
+    const command = refreshExecutable();
     if (!command) throw new Error("codex executable is unavailable");
     if (typeof WebSocket !== "function") {
       throw new Error("Aru Host requires Node.js with WebSocket support");
@@ -204,11 +205,14 @@ export function createCodexAppServerDriver({ executable, resolveExecutable, log 
     threadHandlers.clear();
   }
 
-  function executablePath() {
-    return typeof resolveExecutable === "function" ? resolveExecutable() : executable;
+  function refreshExecutable() {
+    if (typeof resolveExecutable === "function") {
+      knownExecutable = resolveExecutable() ?? null;
+    }
+    return knownExecutable;
   }
 
-  return { status, ensureConnected, startTurn, interrupt };
+  return { status, refreshExecutable, ensureConnected, startTurn, interrupt };
 }
 
 function newThreadInstructions(instructions, historyContext) {

--- a/collaborator-host.mjs
+++ b/collaborator-host.mjs
@@ -82,7 +82,6 @@ export function createCollaboratorHost({
 }) {
   state.agentDriverProbes ??= [];
   state.hostedCollaborators ??= [];
-  let codexExecutable = resolveDriverExecutable(LOCAL_DRIVER_DEFINITIONS[0]);
   const surfaces = createCollaboratorSurfaceHost({
     dataDir,
     readJSONBody,
@@ -107,7 +106,8 @@ export function createCollaboratorHost({
     now,
   });
   const codexDriver = createCodexAppServerDriver({
-    resolveExecutable: () => codexExecutable,
+    executable: resolveDriverExecutable(LOCAL_DRIVER_DEFINITIONS[0]),
+    resolveExecutable: () => resolveDriverExecutable(LOCAL_DRIVER_DEFINITIONS[0]),
     log,
   });
   let providerProfiles;
@@ -189,7 +189,7 @@ export function createCollaboratorHost({
 
   function refreshDrivers() {
     state.agentDriverProbes = LOCAL_DRIVER_DEFINITIONS.map((definition) => probeDriver(definition, now()));
-    codexExecutable = resolveDriverExecutable(LOCAL_DRIVER_DEFINITIONS[0]);
+    codexDriver.refreshExecutable();
     saveState();
     return driverInventory();
   }

--- a/linux-console/package-lock.json
+++ b/linux-console/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aru-host",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aru-host",
-      "version": "0.29.0",
+      "version": "0.29.1",
       "license": "Apache-2.0",
       "dependencies": {
         "qrcode": "^1.5.4"

--- a/linux-console/package.json
+++ b/linux-console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aru-host",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",

--- a/macos-console/Tests/AruHostConsoleTests/HostConsoleModelsTests.swift
+++ b/macos-console/Tests/AruHostConsoleTests/HostConsoleModelsTests.swift
@@ -72,7 +72,7 @@ import Testing
       "schema":"aru.selfhost.collaborator-surface.v1",
       "surfaceId":"surface_1",
       "collaboratorId":"hostcol_1",
-      "title":"Aelion's room",
+      "title":"Mira's room",
       "revision":2,
       "activeVersionId":"version_2",
       "activeVersionOrdinal":2,
@@ -203,9 +203,9 @@ import Testing
         "schema":"aru.selfhost.collaborator-project.v1",
         "projectId":"hostproject_1234",
         "collaboratorId":"hostcol_1234",
-        "title":"Aelion page",
+        "title":"Mira page",
         "revision":3,
-        "workspacePath":"projects/aelion-page",
+        "workspacePath":"projects/mira-page",
         "entryPath":"index.html",
         "sourceURL":"https://github.com/aru/page",
         "repositoryURL":"https://github.com/aru/page.git",
@@ -220,7 +220,7 @@ import Testing
     }
     """#.utf8))
 
-    #expect(inventory.projects.first?.workspacePath == "projects/aelion-page")
+    #expect(inventory.projects.first?.workspacePath == "projects/mira-page")
     #expect(inventory.projects.first?.latestCheckpoint?.artifactId == "artifact_1")
     #expect(inventory.projects.first?.repository?.branch == "main")
     #expect(inventory.projects.first?.surfaceId == "surface_1234")
@@ -232,7 +232,7 @@ import Testing
       "schema":"aru.selfhost.hosted-collaborator-inventory.v1",
       "collaborators":[{
         "collaboratorId":"hostcol_1234",
-        "displayName":"Aelion",
+        "displayName":"Mira",
         "driverId":"codex",
         "revision":3,
         "activationStatus":"driver-ready",
@@ -313,7 +313,7 @@ import Testing
         "schema":"aru.selfhost.collaborator-surface.v1",
         "surfaceId":"surface_1234",
         "collaboratorId":"hostcol_1234",
-        "title":"Aelion's desk",
+        "title":"Mira's desk",
         "revision":4,
         "activeVersionId":"surfacever_2",
         "activeVersionOrdinal":2,
@@ -339,7 +339,7 @@ import Testing
       "schema":"aru.selfhost.collaborator-surface.v1",
       "surfaceId":"surface_1234",
       "collaboratorId":"hostcol_1234",
-      "title":"Aelion's desk",
+      "title":"Mira's desk",
       "revision":4,
       "activeVersionId":"surfacever_2",
       "activeVersionOrdinal":2,

--- a/macos-console/build-app.sh
+++ b/macos-console/build-app.sh
@@ -3,7 +3,7 @@ set -Eeuo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SELFHOST_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-VERSION="${ARU_HOST_VERSION:-0.29.0-dev}"
+VERSION="${ARU_HOST_VERSION:-0.29.1-dev}"
 BUILD_NUMBER="${ARU_HOST_BUILD_NUMBER:-1}"
 OUTPUT_APP="$SCRIPT_DIR/.build-local/Aru Host Console.app"
 SIGNING_IDENTITY="${ARU_HOST_CONSOLE_SIGNING_IDENTITY:-}"

--- a/macos-console/build-local-app.sh
+++ b/macos-console/build-local-app.sh
@@ -3,6 +3,6 @@ set -Eeuo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 exec "$SCRIPT_DIR/build-app.sh" \
-  --version "${ARU_HOST_VERSION:-0.29.0-dev}" \
+  --version "${ARU_HOST_VERSION:-0.29.1-dev}" \
   --build "${ARU_HOST_BUILD_NUMBER:-1}" \
   --output "$SCRIPT_DIR/.build-local/Aru Host Console.app"

--- a/package-macos-release.sh
+++ b/package-macos-release.sh
@@ -3,7 +3,7 @@ set -Eeuo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 OUTPUT="${1:-$PWD/aru-selfhost-macos.tar.gz}"
-VERSION="${2:-${ARU_HOST_VERSION:-0.29.0-dev}}"
+VERSION="${2:-${ARU_HOST_VERSION:-0.29.1-dev}}"
 [[ "$OUTPUT" == /* ]] || OUTPUT="$PWD/$OUTPUT"
 
 mkdir -p "$(dirname "$OUTPUT")"

--- a/tests/apns-push-smoke.mjs
+++ b/tests/apns-push-smoke.mjs
@@ -20,7 +20,7 @@ let saves = 0;
 const deliveries = [];
 const credentialStore = {
   availability: () => ({ supported: true, storage: "test" }),
-  read: () => ({ teamId: "AY22VQ377R", keyId: "AAAAAAAAAA", privateKey: "test" }),
+  read: () => ({ teamId: "TEAMID0000", keyId: "AAAAAAAAAA", privateKey: "test" }),
 };
 const host = createAPNsPushHost({
   state,

--- a/tests/codex-app-server-driver-smoke.mjs
+++ b/tests/codex-app-server-driver-smoke.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createCodexAppServerDriver } from "../codex-app-server-driver.mjs";
+
+class FakeWebSocket {
+  static OPEN = 1;
+
+  constructor() {
+    this.readyState = 0;
+    this.listeners = new Map();
+    queueMicrotask(() => {
+      this.readyState = FakeWebSocket.OPEN;
+      this.dispatch("open", {});
+    });
+  }
+
+  addEventListener(type, listener, options = {}) {
+    const entries = this.listeners.get(type) ?? [];
+    entries.push({ listener, once: options.once === true });
+    this.listeners.set(type, entries);
+  }
+
+  send(value) {
+    const message = JSON.parse(value);
+    if (message.id === undefined) return;
+    queueMicrotask(() => {
+      this.dispatch("message", {
+        data: JSON.stringify({ id: message.id, result: {} }),
+      });
+    });
+  }
+
+  dispatch(type, event) {
+    const entries = this.listeners.get(type) ?? [];
+    this.listeners.set(type, entries.filter((entry) => !entry.once));
+    for (const entry of entries) entry.listener(event);
+  }
+}
+
+const root = mkdtempSync(join(tmpdir(), "aru-codex-driver-"));
+const executable = join(root, "codex");
+writeFileSync(executable, [
+  "#!/bin/sh",
+  "printf 'listening on: ws://127.0.0.1:54321\\n' >&2",
+  "/bin/sleep 0.1",
+].join("\n"));
+chmodSync(executable, 0o755);
+
+const originalWebSocket = globalThis.WebSocket;
+globalThis.WebSocket = FakeWebSocket;
+
+let executableAvailable = false;
+let resolutionCount = 0;
+const driver = createCodexAppServerDriver({
+  executable: null,
+  resolveExecutable() {
+    resolutionCount += 1;
+    return executableAvailable ? executable : null;
+  },
+});
+
+assert.equal(driver.status(), "unavailable");
+assert.equal(resolutionCount, 0, "status reads must not launch executable probes");
+await assert.rejects(() => driver.ensureConnected(), /codex executable is unavailable/);
+assert.equal(resolutionCount, 1);
+
+executableAvailable = true;
+await driver.ensureConnected();
+assert.equal(resolutionCount, 2, "a later connection must retry executable discovery");
+assert.equal(driver.status(), "running");
+
+globalThis.WebSocket = originalWebSocket;
+console.log("ARU_CODEX_APP_SERVER_DRIVER_SMOKE_OK");


### PR DESCRIPTION
## What changed

- Keep passive driver inventory reads free of executable probes.
- Re-resolve the Codex executable before every new app-server connection, so a Host process that missed Codex at startup can recover after an app install or update.
- Synchronize the cached availability hint when the operator explicitly refreshes drivers.
- Add a synthetic regression smoke test and run it in Host Core CI.
- Replace private-style test fixture identities and an unnecessary real signing-team identifier with neutral values.
- Align stable desktop metadata for the 0.29.1 patch release.

## Root cause

The Host resolved the Codex executable once and cached a missing result for the lifetime of the process. Later inventory refreshes could report Codex as ready while turn execution still used the stale unavailable value.

## Verification

- Local Host Core HTTP and installer smoke suites passed.
- APNs, Codex recovery, collaborator host/cognition/conversation/initiative/project, direct-provider, relay, and plugin smokes passed.
- Local macOS Console: 21/21 tests passed.
- Local Linux Console: 5/5 tests passed; installer and x64 package smokes passed.
- Production dependency audit: 0 vulnerabilities.
- Full tracked-tree privacy and private-source parity reviews completed before every push and tag.
- PR CI run 31387152387 and main CI run 31387360586 passed Host Core, macOS, and Linux.
- Release run 31387550392 passed Developer ID signing, Apple notarization, Gatekeeper/package checks, matching-architecture Linux installs, nine-asset checksum verification, and publication.

## Delivery outcome

Merged to `main` as `cd48f4f` and released as [Aru Host 0.29.1](https://github.com/Aevella/aru-host/releases/tag/v0.29.1). This release updates public desktop source and downloads only; it does not change the official VPS or TestFlight. The Home Mac installation was repaired separately and verified locally.